### PR TITLE
fix shapecast and segment shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v0.8](https://github.com/godot-box2d/godot-box2d/releases/tag/v0.7)
+
+- Fixes [SegmentShape2D seems unsupported](https://github.com/appsinacup/godot-box2d/issues/47).
+- Fixes [Shapecast2D node does not detect collisions](https://github.com/appsinacup/godot-box2d/issues/48).
+
 ## [v0.7](https://github.com/godot-box2d/godot-box2d/releases/tag/v0.7)
 
 - [Zero friction physics material does not simulate](https://github.com/appsinacup/godot-box2d/issues/40)

--- a/src/shapes/box2d_shape_segment.cpp
+++ b/src/shapes/box2d_shape_segment.cpp
@@ -7,7 +7,7 @@
 #include <box2d/b2_edge_shape.h>
 #include <box2d/b2_polygon_shape.h>
 
-constexpr float SEGMENT_SIZE = 0.5f;
+constexpr float SEGMENT_SIZE = 1.0;
 
 void Box2DShapeSegment::set_data(const Variant &p_data) {
 	ERR_FAIL_COND(p_data.get_type() != Variant::RECT2);

--- a/src/spaces/box2d_direct_space_state.cpp
+++ b/src/spaces/box2d_direct_space_state.cpp
@@ -136,6 +136,8 @@ bool Box2DDirectSpaceState::_cast_motion(const RID &shape_rid, const Transform2D
 	if (sweep_test_result.collision && closest_safe != nullptr && closest_unsafe != nullptr) {
 		*closest_safe = sweep_test_result.safe_fraction();
 		*closest_unsafe = sweep_test_result.unsafe_fraction(*closest_safe);
+		// TODO rethink/fix the safe/unsafe part
+		*closest_unsafe = sweep_test_result.toi_output.t;
 	}
 	return true;
 }
@@ -163,8 +165,8 @@ bool Box2DDirectSpaceState::_rest_info(const RID &shape_rid, const Transform2D &
 	const Box2DShape *const_shape = server->shape_owner.get_or_null(shape_rid);
 	ERR_FAIL_COND_V(!const_shape, 0);
 	Box2DShape *shape = const_cast<Box2DShape *>(const_shape);
-	Vector<b2Fixture *> query_result = Box2DSweepTest::query_aabb_motion(shape, transform, Vector2(), margin, 0, collision_mask, collide_with_bodies, collide_with_areas, this);
-	Vector<SweepTestResult> sweep_test_results = Box2DSweepTest::multiple_shapes_cast(shape, transform, Vector2(), margin, collide_with_bodies, collide_with_areas, 2048, query_result, this);
+	Vector<b2Fixture *> query_result = Box2DSweepTest::query_aabb_motion(shape, transform, motion, margin, 0, collision_mask, collide_with_bodies, collide_with_areas, this);
+	Vector<SweepTestResult> sweep_test_results = Box2DSweepTest::multiple_shapes_cast(shape, transform, motion, margin, collide_with_bodies, collide_with_areas, 2048, query_result, this);
 	SweepTestResult sweep_test_result = Box2DSweepTest::closest_result_in_cast(sweep_test_results);
 	if (!sweep_test_result.collision) {
 		return false;

--- a/src/spaces/box2d_sweep_test.cpp
+++ b/src/spaces/box2d_sweep_test.cpp
@@ -234,9 +234,7 @@ SweepTestResult Box2DSweepTest::shape_cast(SweepShape p_sweep_shape_A, b2Shape *
 						manifold.normal = -manifold.normal;
 					}
 
-					b2Vec2 normal = manifold.normal;
-					normal.Normalize();
-					if (b2Dot(normal, motion) <= FLT_EPSILON) {
+					if (b2Dot(manifold.normal, motion) <= FLT_EPSILON && !Vector2(motion.x, motion.y).is_zero_approx()) {
 						break;
 					}
 


### PR DESCRIPTION
This makes it so that unsafe part is always returned correctly and unmodified so shape cast works.
Will change the whole way safe/unsafe works after margin is added to box2d.

Fixes https://github.com/appsinacup/godot-box2d/issues/48

Segment shape used a small value for size, 0.5. Increased it to 1 because box2d removed edges from it.

Fixes https://github.com/appsinacup/godot-box2d/issues/47